### PR TITLE
Fix error CS0017: More than 1 entry point defined

### DIFF
--- a/client.cs
+++ b/client.cs
@@ -139,7 +139,7 @@ public class Patch4MS1And3TW {
         }
     }
 
-    public static void Main() {
+    public static void Run() {
         Patch4MS1();
         Patch3TW();
     }
@@ -565,7 +565,7 @@ public class ReversePowerNoid
             //Console.WriteLine("   [-] It seems that we failed to disable ETW :')");
             return false;
         }
-        Patch4MS1And3TW.Main();
+        Patch4MS1And3TW.Run();
         return true;
     }
 

--- a/compile.bat
+++ b/compile.bat
@@ -1,0 +1,4 @@
+@echo off
+C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe /target:exe /out:server.exe server.cs
+
+C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe /r:C:\Windows\assembly\GAC_MSIL\System.Management.Automation\1.0.0.0__31bf3856ad364e35\System.Management.Automation.dll /target:winexe /out:client.exe client.cs


### PR DESCRIPTION
Had an error while compiling using csc.exe
```
client.cs(142,24): error CS0017: Program 'client.exe' has more than one entry
        point defined: 'Patch4MS1And3TW.Main()'.  Compile with /main to specify the type that contains the entry point.
client.cs(725,24): error CS0017: Program 'client.exe' has more than one entry
        point defined: 'ReversePowerNoid.Main()'.  Compile with /main to specify the type that contains the entry point.
```

Replaced `Patch4MS1And3TW.Main()` with `Patch4MS1And3TW.Run()`

Also added a compile.bat for easy compiling